### PR TITLE
Mdl/dbsfixes

### DIFF
--- a/synergydbg.js
+++ b/synergydbg.js
@@ -12,13 +12,11 @@ function hostModule()
     // execute the match on the string str
     for (let i = 0; i < host.currentProcess.Modules.Count(); i++)
     {
-        if (moduleName.exec(host.currentProcess.Modules[i].Name) != null)
+        let match = moduleName.exec(host.currentProcess.Modules[i].Name);
+        if (match != null)
         {
-            const match = moduleName.exec(host.currentProcess.Modules[i].Name);
-            if (match !== null) {
-                // we ignore the match[0] because it's the match for the hole path string
-                return match[2];
-            }
+            // we ignore the match[0] because it's the match for the hole path string
+            return match[2];
         }
     }
     


### PR DESCRIPTION
- Added new showPrettyTraceback (useful when stack frames have >100 args)
- Support matching dbr/dbs.exe that is not the first module in the list
- Only match dbr/dbs.exe
- Added script invoke method that runs dbr/dbs.exe detection automatically